### PR TITLE
feat: check dict length with node length for quick unique key check

### DIFF
--- a/src/annotatedyaml/loader.py
+++ b/src/annotatedyaml/loader.py
@@ -406,6 +406,16 @@ def _handle_mapping_tag(
     loader.flatten_mapping(node)
     nodes = loader.construct_pairs(node)
 
+    # Check first if length of dict is equal to the length of the nodes
+    # This is a quick way to check if the keys are unique
+    try:
+        conv_dict = dict(nodes)
+    except TypeError:
+        pass
+    else:
+        if len(conv_dict) == len(nodes):
+            return _add_reference_to_node_class(NodeDictClass(conv_dict), loader, node)
+
     seen: dict = {}
     for (key, _), (child_node, _) in zip(nodes, node.value, strict=False):
         line = child_node.start_mark.line


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/home-assistant-libs/annotatedyaml/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
Construct a `dict` of the nodes and comparing it to the length of the nodes. This way we can quickly check if the keys are unique without running through the complete node list. 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/home-assistant-libs/annotatedyaml/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
