### PR TITLE
feat: improve performance of adding references with cython pxds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
           - "3.13"
         os:
           - ubuntu-latest
+        extension:
+          - "skip_cython"
+          - "use_cython"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +72,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync --no-python-downloads
+      - name: Install Dependencies
+        run: |
+          if [ "${{ matrix.extension }}" = "skip_cython" ]; then
+            SKIP_CYTHON=1 uv sync --no-python-downloads
+          else
+            REQUIRE_CYTHON=1 uv sync --no-python-downloads
+          fi
         shell: bash
       - run: uv run pytest
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,8 @@ repos:
       - id: mypy
         additional_dependencies: ["types-PyYAML"]
         exclude: "tests"
+  - repo: https://github.com/MarcoGorelli/cython-lint
+    rev: v0.16.6
+    hooks:
+      - id: cython-lint
+      - id: double-quote-cython-strings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools" ]
+requires = [ "setuptools" , "Cython>=3" ]
 
 [project]
 name = "annotatedyaml"
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries",
 ]
+
 
 dependencies = [
     "propcache>0.1",
@@ -89,6 +90,7 @@ addopts = """\
     --cov-report=xml
     """
 pythonpath = [ "src" ]
+
 
 [tool.coverage.run]
 branch = true

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 TO_CYTHONIZE = [
     "src/annotatedyaml/objects.py",
+    "src/annotatedyaml/reference.py",
 ]
 
 EXTENSIONS = [

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,69 @@
-#!/usr/bin/env python
+"""Build optional cython modules."""
 
-# This is a shim to allow GitHub to detect the package, build is done with uv
-# Taken from https://github.com/Textualize/rich
+import logging
+import os
+from distutils.command.build_ext import build_ext
+from typing import Any
 
 import setuptools
 
-if __name__ == "__main__":
-    setuptools.setup(name="annotatedyaml")
+try:
+    from setuptools import Extension
+except ImportError:
+    from distutils.core import Extension
+
+
+_LOGGER = logging.getLogger(__name__)
+
+TO_CYTHONIZE = [
+    "src/annotatedyaml/objects.py",
+]
+
+EXTENSIONS = [
+    Extension(
+        ext.removeprefix("src/").removesuffix(".py").replace("/", "."),
+        [ext],
+        language="c",
+        extra_compile_args=["-O3", "-g0"],
+    )
+    for ext in TO_CYTHONIZE
+]
+
+
+class BuildExt(build_ext):
+    """Build extension class."""
+
+    def build_extensions(self) -> None:
+        """Build extensions."""
+        try:
+            super().build_extensions()
+        except Exception:
+            _LOGGER.info("Failed to build cython extensions")
+
+
+def _build(setup_kwargs: dict[str, Any]) -> None:
+    setup_kwargs["exclude_package_data"] = {
+        pkg: ["*.c"] for pkg in setup_kwargs.get("packages", [setup_kwargs["name"]])
+    }
+    if os.environ.get("SKIP_CYTHON"):
+        return
+    try:
+        from Cython.Build import cythonize
+
+        setup_kwargs.update(
+            {
+                "ext_modules": cythonize(
+                    EXTENSIONS,
+                    compiler_directives={"language_level": "3"},  # Python 3
+                ),
+                "cmdclass": {"build_ext": BuildExt},
+            }
+        )
+    except Exception:
+        if os.environ.get("REQUIRE_CYTHON"):
+            raise
+
+
+setup_kwargs = {"name": "annotatedyaml"}
+_build(setup_kwargs)
+setuptools.setup(**setup_kwargs)

--- a/src/annotatedyaml/loader.py
+++ b/src/annotatedyaml/loader.py
@@ -387,14 +387,13 @@ def _handle_mapping_tag(
     # Check first if length of dict is equal to the length of the nodes
     # This is a quick way to check if the keys are unique
     try:
-        conv_dict = dict(nodes)
+        conv_dict = NodeDictClass(nodes)
     except TypeError:
         pass
     else:
         if len(conv_dict) == len(nodes):
-            mapping = NodeDictClass(conv_dict)
-            _add_reference_to_node_dict_class(mapping, loader, node)
-            return mapping
+            _add_reference_to_node_dict_class(conv_dict, loader, node)
+            return conv_dict
 
     seen: dict = {}
     for (key, _), (child_node, _) in zip(nodes, node.value, strict=False):

--- a/src/annotatedyaml/objects.pxd
+++ b/src/annotatedyaml/objects.pxd
@@ -1,0 +1,18 @@
+import cython
+
+
+cdef class NodeListClass(list):
+
+    cdef public object __config_file__
+    cdef public object __line__
+
+cdef class NodeStrClass(str):
+
+    cdef public object __config_file__
+    cdef public object __line__
+
+
+cdef class NodeDictClass(dict):
+
+    cdef public object __config_file__
+    cdef public object __line__

--- a/src/annotatedyaml/reference.pxd
+++ b/src/annotatedyaml/reference.pxd
@@ -1,0 +1,12 @@
+
+cpdef _add_reference(
+    object obj,
+    object loader,
+    object node
+)
+
+cpdef _add_reference_to_node_class(
+    object obj,
+    object loader,
+    object node
+)

--- a/src/annotatedyaml/reference.pxd
+++ b/src/annotatedyaml/reference.pxd
@@ -1,12 +1,19 @@
+from .objects cimport NodeDictClass, NodeListClass, NodeStrClass
 
-cpdef _add_reference(
-    object obj,
+cpdef _add_reference_to_node_dict_class(
+    NodeDictClass obj,
     object loader,
     object node
 )
 
-cpdef _add_reference_to_node_class(
-    object obj,
+cpdef _add_reference_to_node_list_class(
+    NodeListClass obj,
+    object loader,
+    object node
+)
+
+cpdef _add_reference_to_node_str_class(
+    NodeStrClass obj,
     object loader,
     object node
 )

--- a/src/annotatedyaml/reference.py
+++ b/src/annotatedyaml/reference.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from .objects import NodeDictClass, NodeListClass, NodeStrClass
+
+if TYPE_CHECKING:
+    from .loader import LoaderType
+
+
+def _add_reference_to_node_dict_class(
+    obj: NodeDictClass,
+    loader: LoaderType,
+    node: yaml.nodes.Node,
+) -> None:
+    """Add file reference information to a node class object."""
+    obj.__config_file__ = loader.get_name
+    obj.__line__ = node.start_mark.line + 1
+
+
+def _add_reference_to_node_list_class(
+    obj: NodeListClass,
+    loader: LoaderType,
+    node: yaml.nodes.Node,
+) -> None:
+    """Add file reference information to a node class object."""
+    obj.__config_file__ = loader.get_name
+    obj.__line__ = node.start_mark.line + 1
+
+
+def _add_reference_to_node_str_class(
+    obj: NodeStrClass,
+    loader: LoaderType,
+    node: yaml.nodes.Node,
+) -> None:
+    """Add file reference information to a node class object."""
+    obj.__config_file__ = loader.get_name
+    obj.__line__ = node.start_mark.line + 1


### PR DESCRIPTION
Cythonize the expensive parts of the loader by adding a pxd is added to tell Cython the types of the objects which avoids all the expensive paths to figure out what type each object is.

A `setup.py` has been added to run the cythonize if available. If Cython is not available, pure python will be used.

The pxd approach is used here to keep it easy to change the Python code and avoid having to reimplement code in pyx files.