### PR TITLE
fix: disable Cython build for release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     concurrency: release
+    env:
+      SKIP_CYTHON: 1
     permissions:
       id-token: write
       attestations: write


### PR DESCRIPTION
binary wheels will be built on cibuildwheel

Hopefully this fixes the release process