### PR TITLE
fix: use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools>=75.8.0', 'Cython', "poetry-core>=2.0.0"]
+requires = ['setuptools>=77.0', 'Cython', "poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [project]
@@ -7,7 +7,7 @@ name = "annotatedyaml"
 version = "0.4.4"
 description = "Annotated YAML that supports secrets for Python"
 readme = "README.md"
-license = { text = "Apache Software License 2.0" }
+license = "Apache-2.0"
 authors = [
   { name = "Home Assistant Devs", email = "hello@home-assistant.io" },
 ]
@@ -163,4 +163,3 @@ furo = ">=2023.5.20"
 myst-parser = ">=0.16"
 sphinx = ">=4"
 sphinx-autobuild = ">=2024,<2025"
-


### PR DESCRIPTION
### Description of change
`project.license` with SPDX identifiers is supported with setuptools `v77`.
Note: This will not map to `License-Expression` just yet since poetry support for it is still incomplete.