### PR TITLE
fix(yaml): Allows following of symlinks when walking through files.

### DIFF
--- a/src/annotatedyaml/loader.py
+++ b/src/annotatedyaml/loader.py
@@ -265,7 +265,7 @@ def _is_file_valid(name: str) -> bool:
 
 def _find_files(directory: str, pattern: str) -> Iterator[str]:
     """Recursively load files in a directory."""
-    for root, dirs, files in os.walk(directory, topdown=True):
+    for root, dirs, files in os.walk(directory, topdown=True, followlinks=True):
         dirs[:] = [d for d in dirs if _is_file_valid(d)]
         for basename in sorted(files):
             if _is_file_valid(basename) and fnmatch.fnmatch(basename, pattern):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -599,3 +599,42 @@ def test_getting_annotation(mock_yaml: None) -> None:
     """Test we can fetch annotations in pure python."""
     data = yaml_loader.load_yaml(YAML_CONFIG_FILE)
     assert _get_annotation(data) == ("test.yaml", 1)
+
+
+def test_find_files_without_symlinks(tmp_path: pathlib.Path) -> None:
+    """Test that _find_files correctly finds regular YAML files."""
+    test_dir = tmp_path / "test"
+    test_dir.mkdir()
+
+    # Create YAML files
+    (test_dir / "file1.yaml").write_text("content1")
+    (test_dir / "file2.yaml").write_text("content2")
+    (test_dir / "not_yaml.txt").write_text("not yaml")
+
+    # Call _find_files
+    files = list(yaml_loader._find_files(str(test_dir), "*.yaml"))
+
+    # Assert that only YAML files are found
+    expected = [str(test_dir / "file1.yaml"), str(test_dir / "file2.yaml")]
+    assert sorted(files) == sorted(expected)
+
+
+def test_find_files_with_symlinks(tmp_path: pathlib.Path) -> None:
+    """Test that _find_files correctly handles symlinked files."""
+    test_dir = tmp_path / "test"
+    test_dir.mkdir()
+
+    # Create a YAML file
+    file1 = test_dir / "file1.yaml"
+    file1.write_text("content")
+
+    # Create a symlink to the file
+    symlink_file = test_dir / "symlink.yaml"
+    os.symlink(str(file1), str(symlink_file))
+
+    # Call _find_files
+    files = list(yaml_loader._find_files(str(test_dir), "*.yaml"))
+
+    # Assert that both the original file and the symlink are found
+    expected = [str(file1), str(symlink_file)]
+    assert sorted(files) == sorted(expected)


### PR DESCRIPTION
### Description of change

For many of the `!include*` directives, they don't follow symlinked directories which can lead to unexpected behavior--especially when creating symbolic links into checked out git repositories.

There have been several bugs created over the years, such as home-assistant/core#15778.

### Pull-Request Checklist

- [ x] Code is up-to-date with the `main` branch
- [ x] This pull request follows the [contributing guidelines](https://github.com/home-assistant-libs/annotatedyaml/blob/main/CONTRIBUTING.md).
- [ x] This pull request links relevant issues as `Fixes #0000`
- [x ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [ x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.
