### PR TITLE
workflows: ci.yml introduce riscv64 architecture build and publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,13 @@ jobs:
             qemu: armv7l
             musl: ""
             pyver: cp314t
+          # qemu is slow, make a single runner per Python version
+          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp313}
+          - {os: ubuntu-latest, qemu: riscv64, musl: "",          pyver: cp313}
+          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp314}
+          - {os: ubuntu-latest, qemu: riscv64, musl: "",          pyver: cp314}
+          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp314t}
+          - {os: ubuntu-latest, qemu: riscv64, musl: "",          pyver: cp314t}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Let's add RISC-V to build and publish

Resolves: home-assistant-libs/annotatedyaml#123