### PR TITLE
ci: scope release env and OIDC permissions to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,15 +87,48 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # Dry run on PRs and non-main pushes. No environment, no publish
+  # permissions, no OIDC, so PR runs carry no release blast radius.
+  release-dry-run:
+    needs:
+      - test
+      - lint
+      - commitlint
+    if: github.ref_name != 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Checkout commit for release
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          git checkout -B "$BRANCH" ${{ github.sha }}
+
+      # Do a dry run of PSR
+      - name: Test release
+        uses: python-semantic-release/python-semantic-release@v10
+        with:
+          no_operation_mode: true
+          github_token: noop
+
+  # Real release, only on main. The release environment and write/OIDC
+  # permissions are scoped to this job so they never apply to PR runs.
   release:
     needs:
       - test
       - lint
       - commitlint
-
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     environment: release
-    concurrency: release
+    concurrency: release-${{ github.ref }}
     permissions:
       id-token: write
       attestations: write
@@ -112,22 +145,15 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Checkout commit for release
+        env:
+          BRANCH: ${{ github.ref_name }}
         run: |
-          git checkout -B ${{ github.ref_name }} ${{ github.sha }}
-
-      # Do a dry run of PSR
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@v10
-        if: github.ref_name != 'main'
-        with:
-          no_operation_mode: true
-          github_token: noop
+          git checkout -B "$BRANCH" ${{ github.sha }}
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
         uses: python-semantic-release/python-semantic-release@v10
         id: release
-        if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The release job held id-token: write, contents: write, and the release environment on every trigger including pull requests, even though it only published on main; this splits it into two jobs so PR runs no longer carry release credentials.

## Details

release-dry-run runs on PRs and non-main pushes with only contents: read, no environment and no OIDC, just the python-semantic-release dry run; release runs only on main and keeps the release environment plus write and OIDC permissions scoped to that job, so they never apply to untrusted PR code.

## Test plan

- [ ] workflow YAML parses clean
- [ ] dry-run job runs on this PR, publish job stays skipped
